### PR TITLE
feat: specify the location of the configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ pdf:
 
 ### Commands
 
-Usage: `reliure [options]`
+Usage: `reliure [options] [<configuration file/directory>]`
 
 #### Options:
 

--- a/lib/build.js
+++ b/lib/build.js
@@ -18,27 +18,38 @@ const {
   appendExtraMetadata,
 } = require('./edition')
 
-const FORMAT_LATEX = 'latex'
-const FORMAT_MARKDOWN = 'markdown'
+const FORMATS = [
+  { name: 'LaTeX', extension: 'tex' },
+  { name: 'Markdown', extension: 'md' },
+  { name: 'LibreOffice', extension: 'odt' },
+  { name: 'Microsoft Word', extension: 'docx' },
+]
 
-module.exports = async (config) => {
+module.exports = async (config, options = {}) => {
+  let cwd = options.cwd || process.cwd()
+
   if (!config.filename) {
-    throw new Error('[Reliure] Filename attribute is missing.')
+    throw new Error('Filename attribute is missing.')
   }
 
   if (!config.files || config.files.length === 0) {
-    throw new Error('[Reliure] Files attribute MUST be an array and contains at least one file.')
+    throw new Error('Files attribute MUST be an array and contains at least one file.')
   }
 
   let detectedInputFormat = undefined
-  if (config.files.filter((file) => file.endsWith('.tex')).length !== config.files.length) {
-    detectedInputFormat = FORMAT_LATEX
-  }
-  if (config.files.filter((file) => file.endsWith('.md')).length !== config.files.length) {
-    detectedInputFormat = FORMAT_MARKDOWN
-  }
+  FORMATS.forEach((format) => {
+    if (config.files.every((file) => file.endsWith(`.${format.extension}`))) {
+      detectedInputFormat = format
+    }
+  })
   if (detectedInputFormat === undefined) {
-    throw new Error('[Reliure] Files MUST be in LaTeX or Markdown.')
+    throw new Error(
+      `Files MUST use the same format and be in one of the following formats:
+  - Microsoft Word (.docx)
+  - LibreOffice (.odt)
+  - Markdown (.md)
+  - LaTeX (.tex)`,
+    )
   }
 
   let tempPath = fs.mkdtempSync(path.join(os.tmpdir(), 'reliure-'))
@@ -53,7 +64,7 @@ module.exports = async (config) => {
     }
     if (config.styleSheets && config.styleSheets.length > 0) {
       config.styleSheets.forEach((filename) => {
-        cssContent = `${cssContent}${fs.readFileSync(filename, 'utf8')}`
+        cssContent = `${cssContent}${fs.readFileSync(path.join(cwd, filename), 'utf8')}`
       })
     }
     cssContent = new CleanCSS({
@@ -70,7 +81,7 @@ module.exports = async (config) => {
     if (config.coverImage) {
       // add cover
       args.push(`--epub-cover-image`)
-      args.push(path.join(process.cwd(), config.coverImage))
+      args.push(path.join(cwd, config.coverImage))
     }
   }
 
@@ -86,7 +97,7 @@ module.exports = async (config) => {
     // add before body: Title + Cover
     let latexBeforeBody = latexTitle()
     if (config.coverImage) {
-      latexBeforeBody += latexNewPage() + latexImage(path.join(process.cwd(), config.coverImage)) + latexNumber(false)
+      latexBeforeBody += latexNewPage() + latexImage(path.join(cwd, config.coverImage)) + latexNumber(false)
     }
     let beforeBodyFile = path.join(tempPath, 'beforeBody.tex')
     fs.writeFileSync(beforeBodyFile, latexBeforeBody, 'utf8')
@@ -95,8 +106,7 @@ module.exports = async (config) => {
     // add after body: TOC + Fourth Cover
     let latexAfterBody = latexTOC()
     if (config.fourthCoverImage) {
-      latexAfterBody +=
-        latexNewPage() + latexImage(path.join(process.cwd(), config.fourthCoverImage)) + latexNumber(false)
+      latexAfterBody += latexNewPage() + latexImage(path.join(cwd, config.fourthCoverImage)) + latexNumber(false)
     }
     let afterBodyFile = path.join(tempPath, 'afterBody.tex')
     fs.writeFileSync(afterBodyFile, latexAfterBody, 'utf8')
@@ -115,7 +125,7 @@ module.exports = async (config) => {
   if (config.format === 'mobi') {
     outputFile = path.join(tempPath, 'temp.epub')
   } else {
-    outputFile = path.join(process.cwd(), `${config.filename}.${config.format}`)
+    outputFile = path.join(cwd, `${config.filename}.${config.format}`)
   }
   args.push('-o', outputFile)
 
@@ -127,7 +137,7 @@ module.exports = async (config) => {
   }
 
   // compile with pandoc
-  await nodePandoc(path.join(process.cwd(), config.files[0]), args)
+  await nodePandoc(path.join(cwd, config.files[0]), args)
 
   if (config.format === 'epub' || config.format === 'mobi') {
     // Automatically edit epub: apply substitutions, append extra metadata
@@ -154,6 +164,6 @@ module.exports = async (config) => {
 
   if (config.format === 'mobi') {
     // convert epub to mobi
-    await epubToMobi(outputFile, path.join(process.cwd(), `${config.filename}.mobi`))
+    await epubToMobi(outputFile, path.join(cwd, `${config.filename}.mobi`))
   }
 }

--- a/lib/kindlegen.js
+++ b/lib/kindlegen.js
@@ -106,15 +106,11 @@ module.exports.installKindlegen = async (forceInstall = false) => {
     } else if (process.platform === 'win32') {
       binUrl = 'https://archive.org/download/kindlegen_win32_v2_9/kindlegen_win32_v2_9.zip'
     } else {
-      throw new Error('[Reliure] Unsupported platform.')
+      throw new Error('Unsupported platform.')
     }
-    console.log(
-      'KindleGen is a tool to convert files to the Kindle format (Mobi) enabling publishers to create great-looking books that work on all Kindle devices and apps.',
-    )
-    console.log('KindleGen is officially supported by Amazon.')
-    console.log(
-      'To install KindleGen, you must accept the following terms of use: https://www.amazon.com/gp/feature.html?docId=1000599251',
-    )
+    console.log(`KindleGen is a tool to convert files to the Kindle format (Mobi) enabling publishers to create great-looking books that work on all Kindle devices and apps.
+KindleGen is officially supported by Amazon.
+To install KindleGen, you must accept the following terms of use: https://www.amazon.com/gp/feature.html?docId=1000599251`)
     let install = forceInstall
     if (!install) {
       let { startInstall } = await inquirer.prompt([

--- a/lib/options.js
+++ b/lib/options.js
@@ -4,10 +4,14 @@ const parseArgs = require('minimist')
 const { version } = require('../package.json')
 
 module.exports.getOptions = () => {
-  return parseArgs(process.argv.slice(2), {
+  let options = parseArgs(process.argv.slice(2), {
     boolean: ['epub', 'mobi', 'pdf', 'version', 'help'],
     alias: { v: 'version', h: 'help' },
   })
+  if (options['_'] && options['_'].length > 0) {
+    options.config = options['_'][0]
+  }
+  return options
 }
 
 module.exports.printVersion = () => {
@@ -15,9 +19,10 @@ module.exports.printVersion = () => {
 }
 
 module.exports.printHelp = () => {
-  console.log(`  How to use Reliure ⛑️
+  console.log(`
+  How to use Reliure ⛑️
 
-  Usage: reliure [options]
+  Usage: reliure [options] [configuration file/directory]
 
   Options:
 
@@ -31,6 +36,8 @@ module.exports.printHelp = () => {
   Examples:
 
     reliure --epub --mobi
+    reliure --epub --pdf my-project/
+    reliure --epub --pdf my-complex-project/reliure-config.yml
     reliure -v
     reliure --version
 

--- a/lib/read-config.js
+++ b/lib/read-config.js
@@ -2,15 +2,37 @@ const fs = require('fs')
 const path = require('path')
 const yaml = require('js-yaml')
 
-const FILENAME = 'reliure.yml'
+const DEFAULT_FILENAME = 'reliure.yml'
 
-module.exports = () => {
+module.exports.findConfig = (filename) => {
+  let file
+  if (filename) {
+    if (fs.existsSync(path.join(path.resolve(filename), DEFAULT_FILENAME))) {
+      // check filename with relative path + /reliure.yml
+      file = path.join(path.resolve(filename), DEFAULT_FILENAME)
+    } else if (fs.existsSync(path.resolve(filename))) {
+      // check filename with relative path
+      file = path.resolve(filename)
+    } else if (fs.existsSync(path.join(filename, DEFAULT_FILENAME))) {
+      // check filename with absolute path + /reliure.yml
+      file = path.join(filename, DEFAULT_FILENAME)
+    } else if (fs.existsSync(filename)) {
+      // check filename with absolute path
+      file = filename
+    }
+  } else {
+    file = DEFAULT_FILENAME
+  }
+  return file
+}
+
+module.exports.readConfig = (filename) => {
   try {
-    let config = fs.readFileSync(path.resolve(process.cwd(), FILENAME), 'utf8')
+    let config = fs.readFileSync(filename, 'utf8')
     return yaml.load(config)
   } catch (e) {
     throw new Error(
-      `[Reliure] Please run binding in the directory where the configuration file "${FILENAME}" is located.`,
+      `Please run binding in the directory where the configuration file "${DEFAULT_FILENAME}" is located.`,
     )
   }
 }

--- a/package.json
+++ b/package.json
@@ -44,10 +44,10 @@
     "lint:fix": "eslint . --fix",
     "pretest": "node scripts/github-releases.js",
     "test": "npm-run-all test:*",
-    "test:docx-one-file": "cd tests/docx-one-file && ./../../index.js --epub --mobi --pdf && cd ../.. && java -jar github_releases/w3c/epubcheck/epubcheck-*/epubcheck.jar tests/docx-one-file/*.epub",
-    "test:latex-one-file": "cd tests/latex-one-file && ./../../index.js --epub --mobi --pdf && cd ../.. && java -jar github_releases/w3c/epubcheck/epubcheck-*/epubcheck.jar tests/latex-one-file/*.epub",
-    "test:markdown-one-file": "cd tests/markdown-one-file && ./../../index.js --epub --mobi --pdf && cd ../.. && java -jar github_releases/w3c/epubcheck/epubcheck-*/epubcheck.jar tests/latex-one-file/*.epub",
-    "test:odt-one-file": "cd tests/odt-one-file && ./../../index.js --epub --mobi --pdf && cd ../.. && java -jar github_releases/w3c/epubcheck/epubcheck-*/epubcheck.jar tests/odt-one-file/*.epub",
+    "test:docx-one-file": "./index.js --epub --mobi --pdf tests/docx-one-file && java -jar github_releases/w3c/epubcheck/epubcheck-*/epubcheck.jar tests/docx-one-file/*.epub",
+    "test:latex-one-file": "./index.js --epub --mobi --pdf tests/latex-one-file && java -jar github_releases/w3c/epubcheck/epubcheck-*/epubcheck.jar tests/latex-one-file/*.epub",
+    "test:markdown-one-file": "./index.js --epub --mobi --pdf tests/markdown-one-file && java -jar github_releases/w3c/epubcheck/epubcheck-*/epubcheck.jar tests/latex-one-file/*.epub",
+    "test:odt-one-file": "./index.js --epub --mobi --pdf tests/odt-one-file && java -jar github_releases/w3c/epubcheck/epubcheck-*/epubcheck.jar tests/odt-one-file/*.epub",
     "build": "pkg . --out-path=build"
   },
   "dependencies": {

--- a/tests/docx-one-file/reliure.yml
+++ b/tests/docx-one-file/reliure.yml
@@ -8,7 +8,7 @@ default:
     - ebook.docx
 
   metadata:
-    title: Test - Markdown - Markdown in one file
+    title: Test - Microsoft Office OOXML - Microsoft Office OOXML in one file
     author: Guillaume Gérard
     date: 2020-11
     lang: fr-FR

--- a/tests/odt-one-file/reliure.yml
+++ b/tests/odt-one-file/reliure.yml
@@ -8,7 +8,7 @@ default:
     - ebook.tex
 
   metadata:
-    title: Test - Markdown - Markdown in one file
+    title: Test - LibreOffice - LibreOffice in one file
     author: Guillaume Gérard
     date: 2020-11
     lang: fr-FR


### PR DESCRIPTION
## Feature

### Specify the location of the configuration file (#22)

You can now run reliure with a directory or a file in parameter:
```sh
reliure my-ebook-dir/reliure.yml
reliure my-ebook-dir
```

## Fix

### Detect correctly input formats (#22)

The previous implementation was broken.
Now it detects LaTex, Markdow, LibreOffice Document, Microsft Word OOXML correctly and triggers an error for any other file extension.

## Refactor

### Print error more nicely in the interface (#22)

Remove the cryptic stracktrace and print error message.