### PR TITLE
fix: add prefix to version command

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -15,7 +15,7 @@ module.exports.getOptions = () => {
 }
 
 module.exports.printVersion = () => {
-  console.log(version)
+  console.log(`v${version}`)
 }
 
 module.exports.printHelp = () => {


### PR DESCRIPTION
## Fix

### Add prefix to version command (#24)

It nows displays `v1.6.0` instead of `1.6.0`