### PR TITLE
Fixes `reliure-win.exe` 1.13.0+ crashing on start

### DIFF
--- a/src/get-formats.js
+++ b/src/get-formats.js
@@ -23,7 +23,7 @@ module.exports = (settings, options = {}) => {
     return { formats: result }
   }
 
-  if (!options['non-interactive']) {
+  if (options['non-interactive']) {
     throw new Error('You should specify at least one format')
   }
 


### PR DESCRIPTION
Fixes #57 

The condition testing the `non-interactive` option was reversed: if you _do_ use the option `non-interactive`, then you won't have a prompt asking you what formats you want to build. Therefore, you should have specified the formats already in the command line, so `get-formats` returned a set of formats to build before you reach the condition.