### PR TITLE
Rework `findConfig`

### DIFF
--- a/src/read-config.js
+++ b/src/read-config.js
@@ -7,18 +7,27 @@ const { schemaReliure } = require('./schemas')
 const DEFAULT_FILENAME = 'reliure.yml'
 
 module.exports.findConfig = (pathOption) => {
-  let file
-  if (pathOption) {
-    pathOption = path.isAbsolute(pathOption) ? pathOption : path.resolve(pathOption)
-    if (fs.existsSync(path.join(pathOption, DEFAULT_FILENAME))) {
-      file = path.join(pathOption, DEFAULT_FILENAME)
-    } else if (fs.existsSync(pathOption)) {
-      file = pathOption
-    }
-  } else {
-    file = DEFAULT_FILENAME
+  if (!pathOption) {
+    pathOption = DEFAULT_FILENAME
   }
-  return file
+  if (!fs.existsSync(pathOption)) {
+    throw `Please run binding in the directory where the configuration file "${DEFAULT_FILENAME}" is located.`
+  }
+
+  let stat = fs.statSync(pathOption)
+
+  if (stat.isFile()) {
+    return path.resolve(pathOption)
+  }
+
+  if (stat.isDirectory()) {
+    let configFile = path.join(pathOption, DEFAULT_FILENAME)
+    if (!fs.existsSync(configFile)) {
+      throw `Please run binding in the directory where the configuration file "${DEFAULT_FILENAME}" is located.`
+    }
+
+    return path.resolve(configFile)
+  }
 }
 
 module.exports.readConfig = (filename) => {


### PR DESCRIPTION
This PR reworks `findConfig` function to prepare the ground for the re-archive feature:
- Rename the argument `filename` with `pathOption` because we don't know if the argument is a file or a directory.
- Use `statSync` in addition to `existsSync` to make the result more accurate: if the given path matches a file, then we return it as is; if the given path matches a directory, then we join the `reliure.yml` the folder is supposed to contain.
- Additionally, we can simplify the logic by always resolving the file we return; it shouldn't have any side effects if the given path is absolute.

With this refactoring, we can detect earlier if there's no `reliure.yml` and fallback on the "is epub folder" check we want to implement in a later PR (#67).