### PR TITLE
`--archive` + `--pdf` logging

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "pretest:acceptance": "find ./test -type f \\( -iname '*.epub' -o -iname '*.mobi' -o -iname '*.pdf' \\) -delete",
     "test": "npm-run-all pretest test:unit pretest:acceptance test:acceptance",
     "test:acceptance": "npm-run-all test:acceptance:*",
-    "test:acceptance:archive-folder": "node ./src/index.js --debug --non-interactive --archive test/acceptance/archive-folder/my-ebook && java -jar github_releases/w3c/epubcheck/epubcheck-*/epubcheck.jar test/acceptance/archive-folder/*.epub",
+    "test:acceptance:archive-folder": "node ./src/index.js --debug --non-interactive --archive test/acceptance/archive-folder/my-ebook && java -jar github_releases/w3c/epubcheck/epubcheck-*/epubcheck.jar test/acceptance/archive-folder/my-ebook.epub",
     "test:acceptance:custom-fonts-ttf": "node ./src/index.js --debug --non-interactive --epub --pdf test/acceptance/custom-fonts-ttf && java -jar github_releases/w3c/epubcheck/epubcheck-*/epubcheck.jar test/acceptance/custom-fonts-ttf/*.epub",
     "test:acceptance:custom-fonts-otf": "node ./src/index.js --debug --non-interactive --epub --pdf test/acceptance/custom-fonts-otf && java -jar github_releases/w3c/epubcheck/epubcheck-*/epubcheck.jar test/acceptance/custom-fonts-otf/*.epub",
     "test:acceptance:docx-one-file": "node ./src/index.js --debug --non-interactive --epub --pdf test/acceptance/docx-one-file && java -jar github_releases/w3c/epubcheck/epubcheck-*/epubcheck.jar test/acceptance/docx-one-file/*.epub",

--- a/src/get-formats.js
+++ b/src/get-formats.js
@@ -11,6 +11,10 @@ module.exports = (settings, options = {}) => {
     choices.splice(choices.indexOf('mobi'), 1)
   }
 
+  if (options.archive) {
+    choices.splice(choices.indexOf('pdf'), 1)
+  }
+
   if (options.epub || options.mobi || options.pdf) {
     let result = []
     if (options.epub && choices.includes('epub')) {
@@ -22,7 +26,7 @@ module.exports = (settings, options = {}) => {
     if (options.pdf && choices.includes('pdf')) {
       if (options.archive) {
         warn(
-          '--pdf option is unrelated to the --archive functionality and will be ignored. --archive re-archives a folder that follows EPUB specifications as EPUB or mobi.',
+          'Specified option --pdf is unrelated to the --archive functionality and will be ignored. --archive re-archives a folder that follows EPUB specifications as EPUB or mobi.',
         )
       } else {
         result.push('pdf')
@@ -31,7 +35,7 @@ module.exports = (settings, options = {}) => {
     return { formats: result }
   }
 
-  if (options['non-interactive']) {
+  if (options['non-interactive'] && !options.archive) {
     throw new Error('You should specify at least one format')
   }
 

--- a/src/get-formats.js
+++ b/src/get-formats.js
@@ -1,5 +1,7 @@
 const inquirer = require('inquirer')
 
+const { warn } = require('./message')
+
 const defaultChoices = ['epub', 'mobi', 'pdf']
 
 module.exports = (settings, options = {}) => {
@@ -18,7 +20,13 @@ module.exports = (settings, options = {}) => {
       result.push('mobi')
     }
     if (options.pdf && choices.includes('pdf')) {
-      result.push('pdf')
+      if (options.archive) {
+        warn(
+          '--pdf option is unrelated to the --archive functionality and will be ignored. --archive re-archives a folder that follows EPUB specifications as EPUB or mobi.',
+        )
+      } else {
+        result.push('pdf')
+      }
     }
     return { formats: result }
   }

--- a/src/log-file.js
+++ b/src/log-file.js
@@ -1,5 +1,5 @@
 const { writeFile } = require('fs/promises')
-const { join, resolve, dirname } = require('path')
+const { join, resolve } = require('path')
 
 const LOG_FILENAME = 'reliure.log'
 
@@ -8,9 +8,9 @@ let isEnabled = false
 let location = '.'
 let originalStderrtWrite = undefined
 
-module.exports.initLogging = (configFile) => {
+module.exports.initLogging = (configPath) => {
   isEnabled = true
-  location = resolve(configFile)
+  location = resolve(configPath)
   originalStderrtWrite = process.stderr.write.bind(process.stderr)
   process.stderr.write = (chunk, encoding, callback) => {
     if (typeof chunk === 'string') {
@@ -23,7 +23,7 @@ module.exports.initLogging = (configFile) => {
 module.exports.outputLogFile = async (error) => {
   if (!isEnabled) return
   if (error) console.trace(error)
-  await writeFile(join(dirname(location), LOG_FILENAME), output, 'utf-8')
+  await writeFile(join(location, LOG_FILENAME), output, 'utf-8')
 }
 
 process.on('exit', () => {

--- a/src/read-config.js
+++ b/src/read-config.js
@@ -6,14 +6,17 @@ const { schemaReliure } = require('./schemas')
 
 const DEFAULT_FILENAME = 'reliure.yml'
 
-module.exports.findConfig = (pathOption) => {
+module.exports.ensureConfigPath = (pathOption) => {
   if (!pathOption) {
     pathOption = DEFAULT_FILENAME
   }
   if (!fs.existsSync(pathOption)) {
     throw `Please run binding in the directory where the configuration file "${DEFAULT_FILENAME}" is located.`
   }
+  return pathOption
+}
 
+module.exports.findConfig = (pathOption) => {
   let stat = fs.statSync(pathOption)
 
   if (stat.isFile()) {


### PR DESCRIPTION
Fixes #69.

This PR initially intends to display a simple log when the `--pdf` option is passed with `--archive`, to notify the user that these options are incompatible and `--pdf` will be ignored.

Due to how early in the process the archive task was located, getting this log printed before the process exit required reworking the task ordering a bit. 

(Note that this work will be useful later since we want to give users the possibility to regenerate the mobi out of the re-archive.)

