### PR TITLE
Refactor `get-format.js`

### DIFF
--- a/src/get-formats.js
+++ b/src/get-formats.js
@@ -5,7 +5,7 @@ const { warn } = require('./message')
 const defaultChoices = ['epub', 'mobi', 'pdf']
 
 module.exports = (settings, options = {}) => {
-  if (options['non-interactive']) {
+  if (options['non-interactive'] || Object.keys(options).length > 0) {
     return getFormatFromInline(settings, options)
   } else {
     return getFormatFromPrommpt(settings, options)
@@ -13,8 +13,9 @@ module.exports = (settings, options = {}) => {
 }
 
 const getFormatFromInline = (settings, options) => {
+  let result = []
+
   if (options.epub || options.mobi || options.pdf) {
-    let result = []
     if (options.epub && choices.includes('epub')) {
       result.push('epub')
     }
@@ -36,12 +37,13 @@ const getFormatFromInline = (settings, options) => {
         result.push('pdf')
       }
     }
-    return { formats: result }
   }
 
   if (result.length <= 0 && !options.archive) {
     throw new Error('You should specify at least one format')
   }
+
+  return { formats: result }
 }
 
 const getFormatFromPrommpt = (settings, options) => {

--- a/src/get-formats.js
+++ b/src/get-formats.js
@@ -16,10 +16,10 @@ const getFormatFromInline = (settings, options) => {
   let result = []
 
   if (options.epub || options.mobi || options.pdf) {
-    if (options.epub && choices.includes('epub')) {
+    if (options.epub) {
       result.push('epub')
     }
-    if (options.mobi && choices.includes('mobi')) {
+    if (options.mobi) {
       if (!settings.kindlegenPath) {
         warn(
           'Specified option --mobi will be ignored because mobi format is disabled.',
@@ -28,7 +28,7 @@ const getFormatFromInline = (settings, options) => {
         result.push('mobi')
       }
     }
-    if (options.pdf && choices.includes('pdf')) {
+    if (options.pdf) {
       if (options.archive) {
         warn(
           'Specified option --pdf is unrelated to the --archive functionality and will be ignored. --archive re-archives a folder that follows EPUB specifications as EPUB or mobi.',

--- a/src/get-formats.js
+++ b/src/get-formats.js
@@ -5,16 +5,14 @@ const { warn } = require('./message')
 const defaultChoices = ['epub', 'mobi', 'pdf']
 
 module.exports = (settings, options = {}) => {
-  let choices = defaultChoices
-
-  if (!settings.kindlegenPath) {
-    choices.splice(choices.indexOf('mobi'), 1)
+  if (options['non-interactive']) {
+    return getFormatFromInline(settings, options)
+  } else {
+    return getFormatFromPrommpt(settings, options)
   }
+}
 
-  if (options.archive) {
-    choices.splice(choices.indexOf('pdf'), 1)
-  }
-
+const getFormatFromInline = (settings, options) => {
   if (options.epub || options.mobi || options.pdf) {
     let result = []
     if (options.epub && choices.includes('epub')) {
@@ -35,8 +33,20 @@ module.exports = (settings, options = {}) => {
     return { formats: result }
   }
 
-  if (options['non-interactive'] && !options.archive) {
+  if (!options.archive) {
     throw new Error('You should specify at least one format')
+  }
+}
+
+const getFormatFromPrommpt = (settings, options) => {
+  let choices = defaultChoices
+
+  if (!settings.kindlegenPath) {
+    choices.splice(choices.indexOf('mobi'), 1)
+  }
+
+  if (options.archive) {
+    choices.splice(choices.indexOf('pdf'), 1)
   }
 
   if (choices.length === 1) {

--- a/src/get-formats.js
+++ b/src/get-formats.js
@@ -5,10 +5,10 @@ const { warn } = require('./message')
 const defaultChoices = ['epub', 'mobi', 'pdf']
 
 module.exports = (settings, options = {}) => {
-  if (options['non-interactive'] || Object.keys(options).length > 0) {
+  if (Object.keys(options).length > 0) {
     return getFormatFromInline(settings, options)
   } else {
-    return getFormatFromPrommpt(settings, options)
+    return getFormatFromPrompt(settings, options)
   }
 }
 
@@ -40,13 +40,17 @@ const getFormatFromInline = (settings, options) => {
   }
 
   if (result.length <= 0 && !options.archive) {
-    throw new Error('You should specify at least one format')
+    if (options['non-interactive']) {
+      throw new Error('You should specify at least one format')
+    } else {
+      return getFormatFromPrompt(settings, options)
+    }
   }
 
   return { formats: result }
 }
 
-const getFormatFromPrommpt = (settings, options) => {
+const getFormatFromPrompt = (settings, options) => {
   let choices = defaultChoices
 
   if (!settings.kindlegenPath) {

--- a/src/get-formats.js
+++ b/src/get-formats.js
@@ -19,7 +19,13 @@ const getFormatFromInline = (settings, options) => {
       result.push('epub')
     }
     if (options.mobi && choices.includes('mobi')) {
-      result.push('mobi')
+      if (!settings.kindlegenPath) {
+        warn(
+          'Specified option --mobi will be ignored because mobi format is disabled.',
+        )
+      } else {
+        result.push('mobi')
+      }
     }
     if (options.pdf && choices.includes('pdf')) {
       if (options.archive) {
@@ -33,7 +39,7 @@ const getFormatFromInline = (settings, options) => {
     return { formats: result }
   }
 
-  if (!options.archive) {
+  if (result.length <= 0 && !options.archive) {
     throw new Error('You should specify at least one format')
   }
 }

--- a/test/unit/get-formats.test.js
+++ b/test/unit/get-formats.test.js
@@ -1,0 +1,85 @@
+import { assert, beforeEach, describe, expect, test, vi } from 'vitest'
+
+const getFormat = require('../../src/get-formats.js')
+
+const consoleWarn = vi.spyOn(console, 'warn')
+
+describe('get-formats', function () {
+
+  beforeEach(() => {
+    consoleWarn.mockClear();
+  });
+
+  describe('command line', function () {
+    test('it returns the specified formats', () => {
+      let settings = { kindlegenPath: true }
+      let options = { epub: true, mobi: true, pdf: true }
+      let formats = getFormat(settings, options)
+      expect(formats).toMatchInlineSnapshot(`
+        {
+          "formats": [
+            "epub",
+            "mobi",
+            "pdf",
+          ],
+        }
+      `)
+    })
+
+    test('with kindlegenPath disabled, it removes mobi format', () => {
+      let settings = { kindlegenPath: false }
+      let options = { epub: true, mobi: true, pdf: true }
+      let formats = getFormat(settings, options)
+      expect(formats).toMatchInlineSnapshot(`
+        {
+          "formats": [
+            "epub",
+            "pdf",
+          ],
+        }
+      `)
+
+      expect(consoleWarn).toBeCalledWith(
+        '📙 Specified option --mobi will be ignored because mobi format is disabled.',
+      );
+    })
+
+    test('it throws when no format is specified', () => {
+      let settings = { kindlegenPath: true }
+      let options = { 'non-interactive': true }
+      assert.throws(
+        () => getFormat(settings, options),
+        'You should specify at least one format'
+      )
+    })
+
+    test('with archive option, it removes pdf format', () => {
+      let settings = { kindlegenPath: true }
+      let options = { epub: true, mobi: true, pdf: true, archive: true }
+      let formats = getFormat(settings, options)
+      expect(formats).toMatchInlineSnapshot(`
+        {
+          "formats": [
+            "epub",
+            "mobi",
+          ],
+        }
+      `)
+
+      expect(consoleWarn).toBeCalledWith(
+        '📙 Specified option --pdf is unrelated to the --archive functionality and will be ignored. --archive re-archives a folder that follows EPUB specifications as EPUB or mobi.',
+      );
+    })
+
+    test('with archive option, specifying a format is optional', () => {
+      let settings = { kindlegenPath: true }
+      let options = { archive: true }
+      let formats = getFormat(settings, options)
+      expect(formats).toMatchInlineSnapshot(`
+        {
+          "formats": [],
+        }
+      `)
+    })
+  })
+})


### PR DESCRIPTION
This PR doesn't introduce any new features; it's an internal refactoring. The main purpose is to step back from all the features that were built on top of each other and rewrite the file in a more structured way to ease the implementation of unit tests.

Based on #71 because it adds more vitest tests.