### PR TITLE
Generate mobi out of re-archived epub

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,9 +3,24 @@ name: Test
 on: [push]
 
 jobs:
-  test:
+  lint:
     runs-on: ubuntu-latest
-    name: Tests
+    name: Lint
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+      - run: pnpm install
+      - run: pnpm lint
+
+  acceptance_test:
+    runs-on: ubuntu-latest
+    name: Acceptance
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v2
@@ -26,5 +41,19 @@ jobs:
           sudo dpkg -i pandoc.deb
           rm pandoc.deb
       - run: pnpm install
-      - run: pnpm lint
-      - run: pnpm test
+      - run: pnpm test:acceptance
+
+  unit_test:
+    runs-on: ubuntu-latest
+    name: Unit
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+      - run: pnpm install
+      - run: pnpm test:unit

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "test": "npm-run-all pretest test:unit pretest:acceptance test:acceptance",
     "test:acceptance": "npm-run-all test:acceptance:*",
     "test:acceptance:archive-folder": "node ./src/index.js --debug --non-interactive --archive test/acceptance/archive-folder/my-ebook && java -jar github_releases/w3c/epubcheck/epubcheck-*/epubcheck.jar test/acceptance/archive-folder/my-ebook.epub",
+    "test:acceptance:archive-folder-mobi": "node ./src/index.js --debug --non-interactive --mobi --archive test/acceptance/archive-folder/my-ebook",
     "test:acceptance:custom-fonts-ttf": "node ./src/index.js --debug --non-interactive --epub --pdf test/acceptance/custom-fonts-ttf && java -jar github_releases/w3c/epubcheck/epubcheck-*/epubcheck.jar test/acceptance/custom-fonts-ttf/*.epub",
     "test:acceptance:custom-fonts-otf": "node ./src/index.js --debug --non-interactive --epub --pdf test/acceptance/custom-fonts-otf && java -jar github_releases/w3c/epubcheck/epubcheck-*/epubcheck.jar test/acceptance/custom-fonts-otf/*.epub",
     "test:acceptance:docx-one-file": "node ./src/index.js --debug --non-interactive --epub --pdf test/acceptance/docx-one-file && java -jar github_releases/w3c/epubcheck/epubcheck-*/epubcheck.jar test/acceptance/docx-one-file/*.epub",

--- a/package.json
+++ b/package.json
@@ -42,10 +42,10 @@
   "scripts": {
     "lint": "eslint . --cache",
     "lint:fix": "eslint . --fix",
-    "pretest": "node scripts/github-releases.js",
+    "github-releases": "node scripts/github-releases.js",
     "pretest:acceptance": "find ./test -type f \\( -iname '*.epub' -o -iname '*.mobi' -o -iname '*.pdf' \\) -delete",
-    "test": "npm-run-all pretest test:unit pretest:acceptance test:acceptance",
-    "test:acceptance": "npm-run-all test:acceptance:*",
+    "test": "npm-run-all test:unit test:acceptance",
+    "test:acceptance": "npm-run-all github-releases pretest:acceptance test:acceptance:*",
     "test:acceptance:archive-folder": "node ./src/index.js --debug --non-interactive --archive test/acceptance/archive-folder/my-ebook && java -jar github_releases/w3c/epubcheck/epubcheck-*/epubcheck.jar test/acceptance/archive-folder/my-ebook.epub",
     "test:acceptance:archive-folder-mobi": "node ./src/index.js --debug --non-interactive --mobi --archive test/acceptance/archive-folder/my-ebook",
     "test:acceptance:custom-fonts-ttf": "node ./src/index.js --debug --non-interactive --epub --pdf test/acceptance/custom-fonts-ttf && java -jar github_releases/w3c/epubcheck/epubcheck-*/epubcheck.jar test/acceptance/custom-fonts-ttf/*.epub",

--- a/src/build.js
+++ b/src/build.js
@@ -20,6 +20,7 @@ const {
   opfSubstitutions,
   appendExtraMetadata,
 } = require('./edition')
+const { success } = require('./message')
 
 const FORMATS = [
   { name: 'LaTeX', extension: 'tex' },
@@ -213,5 +214,21 @@ module.exports = async (config, options = {}) => {
       kindlegenPath: options.kindlegenPath,
       debug: options.debug,
     })
+  }
+}
+
+module.exports.rearchive = async (inputFolder, options) => {
+  // The epub has the same name as the folder we rearchive
+  let outputFile = `${inputFolder}.epub`
+  await archive(path.resolve(inputFolder), outputFile)
+  success(`Created archive ${inputFolder}.epub`)
+
+  if (options.mobi) {
+    // convert epub to mobi
+    await epubToMobi(path.resolve(outputFile), `${inputFolder}.mobi`, {
+      kindlegenPath: options.kindlegenPath,
+      debug: options.debug,
+    })
+    success(`Created archive ${inputFolder}.mobi`)
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ const clear = require('clear')
 const path = require('path')
 
 const build = require('./build')
-const { archive } = require('./edition')
+const { rearchive } = require('./build')
 const getFormats = require('./get-formats')
 const { detectOrInstallKindlegen } = require('./kindlegen')
 const { initLogging, outputLogFile } = require('./log-file')
@@ -45,8 +45,11 @@ const options = getOptions()
   let { formats } = await getFormats(settings, options)
 
   if (options.archive) {
-    await archive(options.config, `${options.config}.epub`)
-    success(`Created archive ${options.config}.epub`)
+    await rearchive(options.config, {
+      mobi: formats.includes('mobi'),
+      kindlegenPath: settings.kindlegenPath,
+      debug: options.debug,
+    })
     return
   }
 


### PR DESCRIPTION
Fixes #68 

**Re-archive includes mobi**

When the new `--archive` option is used, the formats passed to the command line are now considered. If `--mobi` is passed, then the mobi will be regenerated out of the re-archived epub.

**Tests matrix**

Because this PR triggers a new test on CI, it includes a clearer separation between unit tests and acceptance tests, so the test results are easier to check. (In a later PR, the CI should probably check the existence of the generated file; here we just check the process exits without error.)