### PR TITLE
write a different message for loading error

### DIFF
--- a/src/read-config.js
+++ b/src/read-config.js
@@ -35,9 +35,10 @@ export function readConfig(filename) {
     let rawConfig = fs.readFileSync(filename, 'utf8')
     return load(rawConfig)
   } catch (e) {
-    throw new Error(
-      `Please run binding in the directory where the configuration file "${DEFAULT_FILENAME}" is located.`,
-    )
+    throw new Error(`
+      Could not read the configuration file "${filename}". Please check for syntax errors.
+      ${e}
+    `)
   }
 }
 export function validateConfig(config) {


### PR DESCRIPTION
Currently we use the same error message when the config file is not found and when it's found but can't be loaded. This is very confusing. This PR changes the message for the loading error. 